### PR TITLE
eat: add Monaco code editor and language selector to /editor route

### DIFF
--- a/app/editor/components/LanguageSelector.tsx
+++ b/app/editor/components/LanguageSelector.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+type Props = {
+  language: string;
+  setLanguage: (val: string) => void;
+};
+
+const languages = ["javascript", "typescript", "python", "html", "css"];
+
+export default function LanguageSelector({ language, setLanguage }: Props) {
+  return (
+    <select
+      value={language}
+      onChange={(e) => setLanguage(e.target.value)}
+      className="bg-zinc-800 text-white p-2 rounded"
+    >
+      {languages.map((lang) => (
+        <option key={lang} value={lang}>
+          {lang.toUpperCase()}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/editor/components/MonacoCodeEditor.tsx
+++ b/app/editor/components/MonacoCodeEditor.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Editor from "@monaco-editor/react";
+
+type Props = {
+  code: string;
+  setCode: (value: string) => void;
+  language: string;
+};
+
+export function MonacoCodeEditor({ code, setCode, language }: Props) {
+  return (
+    <Editor
+      height="100%"
+      defaultLanguage={language}
+      value={code}
+      onChange={(val) => setCode(val || "")}
+      theme="vs-dark"
+      options={{
+        fontSize: 16,
+        minimap: { enabled: false },
+        padding: { top: 16 },
+      }}
+    />
+  );
+}

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import LanguageSelector from "./components/LanguageSelector";
+import { MonacoCodeEditor } from "./components/MonacoCodeEditor";
+
+export default function EditorPage() {
+  const [code, setCode] = useState("// Start coding...");
+  const [language, setLanguage] = useState("javascript");
+
+  return (
+    <main className="min-h-screen p-6 bg-zinc-900 text-white">
+      <h1 className="text-2xl font-bold mb-4">Code Slides Editor</h1>
+
+      <div className="flex gap-4">
+        <LanguageSelector language={language} setLanguage={setLanguage} />
+      </div>
+
+      <div className="mt-4 h-[500px] border rounded overflow-hidden">
+        <MonacoCodeEditor code={code} setCode={setCode} language={language} />
+      </div>
+    </main>
+  );
+}

--- a/app/preview/page.tsx
+++ b/app/preview/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const page = () => {
+  return <div>page</div>;
+};
+
+export default page;

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const page = () => {
+  return <div>template page</div>;
+};
+
+export default page;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
@@ -789,6 +790,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5246,6 +5270,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6447,6 +6478,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",


### PR DESCRIPTION
📝 **Pull Request Description:**
This PR introduces the initial editor functionality to the /editor route. Key features implemented:

**✨ Features**

- Added Monaco Code Editor with basic configuration and dark theme
- Implemented language selector dropdown (JavaScript, TypeScript, Python, HTML, CSS)
- Created MonacoCodeEditor and LanguageSelector components under /components/Editor
- Setup /editor route with clean layout and state handling
- Established scalable folder structure for future routes (preview, templates, etc.)

📁 Structure Improvements

- Grouped components into logical folders for Editor/ and UI/
- Prepared layout and route for upcoming slide editor and animation controls

🚧 Next Steps

- Add syntax-highlighted preview block for rendered code
- Support theme, padding, and font customizations
- Integrate animation and export controls